### PR TITLE
chore: add encoding param to getMultipleAccounts

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1712,6 +1712,16 @@ export type GetParsedProgramAccountsConfig = {
 };
 
 /**
+ * Configuration object for getParsedProgramAccounts
+ */
+export type GetMultipleAccountsConfig = {
+  /** Optional commitment level */
+  commitment?: Commitment;
+  /** Optional encoding for account data (default base64) */
+  encoding?: 'base64' | 'jsonParsed';
+};
+
+/**
  * Information describing an account
  */
 export type AccountInfo<T> = {
@@ -2479,10 +2489,23 @@ export class Connection {
    */
   async getMultipleAccountsInfo(
     publicKeys: PublicKey[],
-    commitment?: Commitment,
+    configOrCommitment?: GetMultipleAccountsConfig | Commitment,
   ): Promise<(AccountInfo<Buffer> | null)[]> {
     const keys = publicKeys.map(key => key.toBase58());
-    const args = this._buildArgs([keys], commitment, 'base64');
+
+    let commitment;
+    let encoding: 'base64' | 'jsonParsed' = 'base64';
+    if (configOrCommitment) {
+      if (typeof configOrCommitment === 'string') {
+        commitment = configOrCommitment;
+        encoding = 'base64';
+      } else {
+        commitment = configOrCommitment.commitment;
+        encoding = configOrCommitment.encoding || 'base64';
+      }
+    }
+
+    const args = this._buildArgs([keys], commitment, encoding);
     const unsafeRes = await this._rpcRequest('getMultipleAccounts', args);
     const res = create(
       unsafeRes,


### PR DESCRIPTION
It'd be nice to get parsed data when requesting multiple accounts so this allows you to add an encoding when making a request to `getMultipleAccounts`.